### PR TITLE
Feature/add reset prediction

### DIFF
--- a/app/api/prediction.py
+++ b/app/api/prediction.py
@@ -104,7 +104,7 @@ def predict():
 
 
 @bp.route("/prediction/reset", methods=["POST"])
-def save_prediction():
+def reset_prediction():
     query = "reset_test_data"
     conn = db().get_connection()
     cursor = conn.cursor()

--- a/app/api/prediction.py
+++ b/app/api/prediction.py
@@ -68,7 +68,7 @@ def predict():
         predictions_sess = session.get("predictions")
         predictions_sess[id_] = predictions[id_]
         session["predictions"] = predictions_sess
-        flash("1 employee sucessfully predicted.")
+        flash("1 employee successfully predicted.")
 
         return render_template("prediction.html", test_data=test_data)
 
@@ -98,31 +98,24 @@ def predict():
 
     session["predictions"] = predictions_sess
 
-    if len(test_id) > 1:
-        flash(str(len(test_id)) + " employees sucessfully predicted.")
-    else:
-        flash(str(len(test_id)) + " employee sucessfully predicted.")
+    flash(str(len(test_id)) + " employee successfully predicted.")
 
     return render_template("prediction.html", test_data=test_data)
 
 
-@bp.route("/prediction/save", methods=["POST"])
+@bp.route("/prediction/reset", methods=["POST"])
 def save_prediction():
-    predictions_sess = session.get("predictions")
-    predicted_id = predictions_sess.keys()
-
-    query = "set_employee_attrition"
+    query = "reset_test_data"
     conn = db().get_connection()
     cursor = conn.cursor()
 
-    for id_ in predicted_id:
-        cursor.callproc(query, [id_, predictions_sess[id_]])
-        conn.commit()
+    cursor.callproc(query)
+    conn.commit()
 
     cursor.close()
     conn.close()
 
-    flash(str(len(predicted_id)) + " prediction data sucessfully saved.")
+    flash("All prediction data successfully reset.")
     session.pop("predictions", None)
 
     return redirect(url_for("api.prediction"))

--- a/app/templates/prediction.html
+++ b/app/templates/prediction.html
@@ -24,9 +24,9 @@
                 </form>
               </div>
               <div class="col">
-                <form action="/prediction/save" method="POST">
-                  <input type="hidden" name="predict_type" value="save">
-                  <input class="btn btn-secondary btn-sm shadow-sm" type="submit" value="Save Predictions">
+                <form action="/prediction/reset" method="POST">
+                  <input type="hidden" name="predict_type" value="reset">
+                  <input class="btn btn-secondary btn-sm shadow-sm" type="submit" value="Reset Prediction Data">
                 </form>
               </div>
             </div>


### PR DESCRIPTION
Added a feature to reset employee attrition prediction data. It add a new route "prediction/reset" for the reset_prediction function in the prediction API (prediction.py). The route "prediction/save" was removed and the (button) option to access it was replaced by the option to access the new feature in app/templates/prediction.html"